### PR TITLE
Annonce vocalement le succès ou l'erreur des conditions du mot de passe

### DIFF
--- a/confiture-web-app/src/components/ui/DsfrPassword.vue
+++ b/confiture-web-app/src/components/ui/DsfrPassword.vue
@@ -101,6 +101,8 @@ const requirementClass = computed(() => {
           v-for="requirement in requirements"
           :key="requirement"
           :class="`fr-message ${requirementClass}`"
+          data-fr-valid="validé"
+          data-fr-error="en erreur"
         >
           {{ requirement }}
         </p>


### PR DESCRIPTION
Ajouter le `data-fr-valid` et `data-fr-error` qui ajoute à la description "- validé" ou "en erreur" quand la condition est validée ou en erreur.

closes #1227 