### PR TITLE
Ne duplique pas les champs de la déclaration lors de la copie d'un audit.

### DIFF
--- a/confiture-rest-api/src/audits/audit.service.ts
+++ b/confiture-rest-api/src/audits/audit.service.ts
@@ -1252,10 +1252,25 @@ export class AuditService {
     const newAudit = await this.prisma.audit.create({
       data: {
         ...omit(originalAudit, [
+          // ignore ids
           "id",
           "auditTraceId",
           "sourceAuditId",
-          "transverseElementsPageId"
+          "transverseElementsPageId",
+
+          // reset statement fields
+          "procedureUrl",
+          "initiator",
+          "auditorOrganisation",
+          "contactName",
+          "contactEmail",
+          "contactFormUrl",
+          "technologies",
+          "tools",
+          "environments",
+          "notCompliantContent",
+          "derogatedContent",
+          "notInScopeContent"
         ]),
 
         // link new audit with the original
@@ -1273,14 +1288,8 @@ export class AuditService {
         creationDate: new Date(),
         editionDate: undefined,
         publicationDate: undefined,
-
-        environments: {
-          createMany: {
-            data: originalAudit.environments.map((e) =>
-              omit(e, ["id", "auditUniqueId"])
-            )
-          }
-        },
+        statementPublicationDate: undefined,
+        statementEditionDate: undefined,
 
         transverseElementsPage: {
           create: {


### PR DESCRIPTION
closes #1323 