### PR TITLE
1387 impossible dinterchanger le nom de 2 pages dans les paramètres de laudit

### DIFF
--- a/confiture-rest-api/src/audits/audit.service.ts
+++ b/confiture-rest-api/src/audits/audit.service.ts
@@ -66,8 +66,8 @@ const hasNamesAreIdenticalButReordered = (currentAuditPages: { name: string; ord
   const namesInOrder = orderBy(intersectingCurrentAuditPages, x => x.order).map(p => p.name);
   const previousNamesInOrder = orderBy(intersectingPreviousAuditPages, x => x.order).map(p => p.name);
 
-  return namesInOrder.length === previousNamesInOrder.length &&
-        JSON.stringify(namesInOrder) !== JSON.stringify(previousNamesInOrder) &&
+  return isEqual(namesInOrder.length, previousNamesInOrder.length) &&
+        !isEqual(JSON.stringify(namesInOrder), JSON.stringify(previousNamesInOrder)) &&
         namesInOrder.every(name => previousNamesInOrder.includes(name)) &&
         previousNamesInOrder.every(name => namesInOrder.includes(name));
 };
@@ -398,8 +398,7 @@ export class AuditService {
 
       if (updatedPages.length > 0) {
         // If reorganization detected, temporarily rename to avoid database integrity constraints
-        const namesAreIdenticalButReordered = hasNamesAreIdenticalButReordered(updatedPages, previousAudit.pages);
-        if (namesAreIdenticalButReordered) {
+        if (hasNamesAreIdenticalButReordered(updatedPages, previousAudit.pages)) {
           await this.prisma.$transaction(async (tx) => {
             // temporary slugs
             for (const p of updatedPages) {

--- a/confiture-web-app/src/components/audit/AraTabs.vue
+++ b/confiture-web-app/src/components/audit/AraTabs.vue
@@ -251,7 +251,7 @@ watch(
             v-else
             class="fr-mr-2v"
           ></component>
-          <span class="tab-label">{{ tab.label }}</span>
+          <span data-cy="tab-label">{{ tab.label }}</span>
           <span v-if="tabs[i].hiddenLabelSuffix" class="fr-sr-only">{{ tabs[i].hiddenLabelSuffix }}</span>
         </button>
       </li>

--- a/cypress/e2e/audit.cy.ts
+++ b/cypress/e2e/audit.cy.ts
@@ -268,7 +268,7 @@ describe("Audit", () => {
         `http://localhost:3000/audits/${editId}/generation/${TabSlug.AUDIT_COMMON_ELEMENTS_SLUG}`
       );
 
-      cy.get("[role='tablist'] button span.tab-label").then((els) => {
+      cy.get("[data-cy='tab-label']").then((els) => {
         expect(els).to.have.length(7);
         const expectedPages = [
           "Éléments transverses",
@@ -325,7 +325,7 @@ describe("Audit", () => {
         `http://localhost:3000/audits/${editId}/generation/${TabSlug.AUDIT_COMMON_ELEMENTS_SLUG}`
       );
 
-      cy.get("[role='tablist'] button span.tab-label").then((els) => {
+      cy.get("[data-cy='tab-label']").then((els) => {
         expect(els).to.have.length(9);
         const expectedPages = [
           "Éléments transverses",


### PR DESCRIPTION
closes #1387](https://github.com/DISIC/Ara/issues/1387)

Avant de merger la pull request, s’assurer que :

- Les checks GitHub passent (lint...).
- Les tests Cypress ont été lancés en local (dans le cas d’une correction de bug ou d’une nouvelle fonctionnalité).
