### PR TITLE
Tiptap : suppression de l’extension Underline

### DIFF
--- a/confiture-web-app/src/components/tiptap/tiptap-extensions.ts
+++ b/confiture-web-app/src/components/tiptap/tiptap-extensions.ts
@@ -98,7 +98,8 @@ const commonExtensions: Extensions = [
     codeBlock: false,
     dropcursor: false,
     heading: false,
-    link: false
+    link: false,
+    underline: false
   }),
   CodeBlockLowlight.configure({ lowlight, defaultLanguage: "html" }),
   Typography.configure({


### PR DESCRIPTION
C’est apparu en migrant Tiptap de la version 2 à la version 3
Voir [Upgrade v2 to v3 | Tiptap Collaboration Docs](https://tiptap.dev/docs/guides/upgrade-tiptap-v2#starterkit-updates)

closes #1462

Avant de merger la pull request, s’assurer que :

- Les checks GitHub passent (lint...).
- Les tests Cypress ont été lancés en local (dans le cas d’une correction de bug ou d’une nouvelle fonctionnalité).
