### PR TITLE
Fait le ménage dans les différentes méthodes findAudit***

### DIFF
--- a/confiture-rest-api/src/audits/audit-export.service.ts
+++ b/confiture-rest-api/src/audits/audit-export.service.ts
@@ -84,7 +84,10 @@ export class AuditExportService {
     consultUniqueId: string
   ): Promise<StreamableFile> {
     const audit =
-      await this.auditService.getAuditWithConsultUniqueId(consultUniqueId);
+      await this.prisma.audit.findUnique({
+        where: { consultUniqueId },
+        include: { pages: true }
+      });
     const results = await this.auditService.getResultsWithEditUniqueId(
       audit.editUniqueId
     );

--- a/confiture-rest-api/src/audits/audit-export.service.ts
+++ b/confiture-rest-api/src/audits/audit-export.service.ts
@@ -8,6 +8,7 @@ import {
   CriterionResultStatus
 } from "../generated/prisma/client";
 
+import { PrismaService } from "../prisma.service";
 import { AuditService } from "./audit.service";
 import { CRITERIA_BY_AUDIT_TYPE } from "./criteria";
 import { CriterionResultDto } from "./dto/entities/criterion-result.dto";
@@ -23,7 +24,10 @@ const CRITERIUM_STATUS: Record<CriterionResultStatus, string> = {
 
 @Injectable()
 export class AuditExportService {
-  constructor(private readonly auditService: AuditService) {}
+  constructor(
+    private readonly auditService: AuditService,
+    private readonly prisma: PrismaService
+  ) { }
 
   private generateCsvExport(
     audit: Audit & {
@@ -89,12 +93,11 @@ export class AuditExportService {
   }
 
   async getCsvExport(editUniqueId: string): Promise<StreamableFile> {
-    const audit = (await this.auditService.findAuditWithEditUniqueId(
-      editUniqueId,
-      { pages: true }
-    )) as Audit & {
-      pages: AuditedPage[];
-    };
+    const audit = await this.prisma.audit.findUnique({
+      where: { editUniqueId },
+      include: { pages: true }
+    });
+
     const results =
       await this.auditService.getResultsWithEditUniqueId(editUniqueId);
 

--- a/confiture-rest-api/src/audits/audit.service.ts
+++ b/confiture-rest-api/src/audits/audit.service.ts
@@ -206,22 +206,6 @@ export class AuditService {
     });
   }
 
-  getAuditWithEditUniqueId(uniqueId: string) {
-    return this.prisma.audit.findUnique({
-      where: { editUniqueId: uniqueId },
-      include: {
-        environments: true,
-        pages: true,
-        sourceAudit: {
-          select: {
-            procedureName: true
-          }
-        },
-        notesFiles: true
-      }
-    });
-  }
-
   getAuditWithConsultUniqueId(uniqueId: string) {
     return this.prisma.audit.findUnique({
       where: { consultUniqueId: uniqueId },

--- a/confiture-rest-api/src/audits/audit.service.ts
+++ b/confiture-rest-api/src/audits/audit.service.ts
@@ -77,7 +77,7 @@ export class AuditService {
   constructor(
     private readonly prisma: PrismaService,
     private readonly fileStorageService: FileStorageService
-  ) {}
+  ) { }
 
   async createAudit(data: CreateAuditDto): Promise<AuditDto> {
     const editUniqueId = nanoid();
@@ -172,7 +172,7 @@ export class AuditService {
     const existingSlugs = new Set<string>([TRANSVERSE_ELEMENTS_SLUG]);
     const pagesWithSlug = pages.map(page => {
       let slug = slugify(page.name);
-      for (let i = 1; ;i++) {
+      for (let i = 1; ; i++) {
         if (!existingSlugs.has(slug)) {
           break;
         }
@@ -182,6 +182,20 @@ export class AuditService {
       return { ...page, slug };
     });
     return pagesWithSlug;
+  }
+
+  /**
+   * @param editUniqueId id of the audit to look for
+   * @param isHidden look for hidden audits, default: false
+   * @returns true if the audit exists in db, false otherwise
+   */
+  async checkIfAuditExists(editUniqueId: string, isHidden: boolean = false): Promise<boolean> {
+    const audit = await this.prisma.audit.findFirst({
+      where: { editUniqueId, isHidden },
+      select: { id: true }
+    });
+
+    return !!audit;
   }
 
   findAuditWithEditUniqueId(uniqueId: string, include?: Prisma.AuditInclude) {

--- a/confiture-rest-api/src/audits/audit.service.ts
+++ b/confiture-rest-api/src/audits/audit.service.ts
@@ -198,10 +198,11 @@ export class AuditService {
     return !!audit;
   }
 
-  findAuditWithEditUniqueId(uniqueId: string, include?: Prisma.AuditInclude) {
+  /** Find and return an audit in the format that the API would return */
+  findAuditWithEditUniqueId(uniqueId: string): Promise<AuditDto> {
     return this.prisma.audit.findFirst({
       where: { editUniqueId: uniqueId, isHidden: false },
-      include
+      select: AUDIT_PRISMA_SELECT
     });
   }
 
@@ -1344,8 +1345,11 @@ export class AuditService {
   }
 
   async isAuditComplete(uniqueId: string): Promise<boolean> {
-    const audit = await this.findAuditWithEditUniqueId(uniqueId, {
-      pages: true
+    const audit = await this.prisma.audit.findUnique({
+      where: { editUniqueId: uniqueId },
+      include: {
+        pages: true
+      }
     });
 
     const testedCount = await this.prisma.criterionResult.count({

--- a/confiture-rest-api/src/audits/audit.service.ts
+++ b/confiture-rest-api/src/audits/audit.service.ts
@@ -206,21 +206,6 @@ export class AuditService {
     });
   }
 
-  getAuditWithConsultUniqueId(uniqueId: string) {
-    return this.prisma.audit.findUnique({
-      where: { consultUniqueId: uniqueId },
-      include: {
-        environments: true,
-        pages: true,
-        sourceAudit: {
-          select: {
-            procedureName: true
-          }
-        }
-      }
-    });
-  }
-
   async getResultsWithEditUniqueId(
     uniqueId: string
   ): Promise<

--- a/confiture-rest-api/src/audits/audit.service.ts
+++ b/confiture-rest-api/src/audits/audit.service.ts
@@ -199,7 +199,7 @@ export class AuditService {
   }
 
   /** Find and return an audit in the format that the API would return */
-  findAuditWithEditUniqueId(uniqueId: string): Promise<AuditDto> {
+  findAudit(uniqueId: string): Promise<AuditDto> {
     return this.prisma.audit.findFirst({
       where: { editUniqueId: uniqueId, isHidden: false },
       select: AUDIT_PRISMA_SELECT

--- a/confiture-rest-api/src/audits/audits.controller.ts
+++ b/confiture-rest-api/src/audits/audits.controller.ts
@@ -206,13 +206,13 @@ export class AuditsController {
     )
     file: Express.Multer.File
   ): Promise<NotesFileDto> {
-    const audit = await this.auditService.getAuditWithEditUniqueId(uniqueId);
+    const exists = await this.auditService.checkIfAuditExists(uniqueId);
 
-    if (!audit) {
+    if (!exists) {
       await this.sendAuditNotFoundStatus(uniqueId);
     }
 
-    return await this.auditService.saveNotesFile(uniqueId, file);
+    return this.auditService.saveNotesFile(uniqueId, file);
   }
 
   @Post("/editor/images")

--- a/confiture-rest-api/src/audits/audits.controller.ts
+++ b/confiture-rest-api/src/audits/audits.controller.ts
@@ -189,9 +189,9 @@ export class AuditsController {
     file: Express.Multer.File,
     @Body() body: UploadImageDto
   ): Promise<ExampleImageFileDto> {
-    const audit = await this.auditService.findAuditWithEditUniqueId(uniqueId);
+    const exists = await this.auditService.checkIfAuditExists(uniqueId);
 
-    if (!audit) {
+    if (!exists) {
       await this.sendAuditNotFoundStatus(uniqueId);
     }
 
@@ -307,9 +307,9 @@ export class AuditsController {
     @Param("uniqueId") uniqueId: string,
     @Body() body: UpdateResultsDto
   ) {
-    const audit = await this.auditService.findAuditWithEditUniqueId(uniqueId);
+    const exists = await this.auditService.checkIfAuditExists(uniqueId);
 
-    if (!audit) {
+    if (!exists) {
       await this.sendAuditNotFoundStatus(uniqueId);
     }
 

--- a/confiture-rest-api/src/audits/audits.controller.ts
+++ b/confiture-rest-api/src/audits/audits.controller.ts
@@ -92,7 +92,7 @@ export class AuditsController {
   @ApiNotFoundResponse({ description: "The audit does not exist." })
   @ApiGoneResponse({ description: "The audit has been previously deleted." })
   async getAudit(@Param("uniqueId") uniqueId: string): Promise<AuditDto> {
-    const audit = await this.auditService.findAuditWithEditUniqueId(uniqueId);
+    const audit = await this.auditService.findAudit(uniqueId);
 
     if (!audit) {
       await this.sendAuditNotFoundStatus(uniqueId);

--- a/confiture-rest-api/src/audits/audits.controller.ts
+++ b/confiture-rest-api/src/audits/audits.controller.ts
@@ -92,21 +92,7 @@ export class AuditsController {
   @ApiNotFoundResponse({ description: "The audit does not exist." })
   @ApiGoneResponse({ description: "The audit has been previously deleted." })
   async getAudit(@Param("uniqueId") uniqueId: string): Promise<AuditDto> {
-    const audit = await this.auditService.findAuditWithEditUniqueId(uniqueId, {
-      environments: true,
-      transverseElementsPage: true,
-      pages: true,
-      sourceAudit: {
-        select: {
-          procedureName: true
-        }
-      },
-      notesFiles: {
-        orderBy: {
-          id: "desc"
-        }
-      }
-    });
+    const audit = await this.auditService.findAuditWithEditUniqueId(uniqueId);
 
     if (!audit) {
       await this.sendAuditNotFoundStatus(uniqueId);
@@ -322,6 +308,11 @@ export class AuditsController {
   @ApiNotFoundResponse({ description: "The audit does not exist." })
   @ApiGoneResponse({ description: "The audit has been previously deleted." })
   async publishAudit(@Param("uniqueId") uniqueId: string): Promise<AuditDto> {
+    const exists = await this.auditService.checkIfAuditExists(uniqueId);
+    if (!exists) {
+      await this.sendAuditNotFoundStatus(uniqueId);
+    }
+
     const auditIsComplete = await this.auditService.isAuditComplete(uniqueId);
     if (!auditIsComplete) {
       throw new ConflictException(
@@ -330,10 +321,6 @@ export class AuditsController {
     }
 
     const audit = await this.auditService.publishAudit(uniqueId);
-
-    if (!audit) {
-      await this.sendAuditNotFoundStatus(uniqueId);
-    }
 
     return audit;
   }
@@ -398,13 +385,13 @@ export class AuditsController {
   @ApiNotFoundResponse({ description: "The audit does not exist." })
   @ApiGoneResponse({ description: "The audit has been previously deleted." })
   async getCsvExport(@Param("uniqueId") uniqueId: string) {
-    const file = await this.auditExportService.getCsvExport(uniqueId);
+    const exists = await this.auditService.checkIfAuditExists(uniqueId);
 
-    if (!file) {
+    if (!exists) {
       return this.sendAuditNotFoundStatus(uniqueId);
     }
 
-    return file;
+    return this.auditExportService.getCsvExport(uniqueId);
   }
 
   /**


### PR DESCRIPTION
Il existait plusieurs méthodes pour récupérer des audits avec des noms légérements différents, et dont les différences étaient vagues et/ou pas cohérentes.

- `findAuditWithEditUniqueId`
- `getAuditWithEditUniqueId`
- `getAuditWithConsultUniqueId`

Cette PR fait le ménage dans tout ça et ne laisse qu’une seule méthode `findAuditWithEditUniqueId()` qui retourne une entité `Audit` avec ses relations (objets nestés) remplies de sorte à pouvoir être retournée directement par l’API (type `AuditDto`)

TODO (dans une autre PR): refactor la vérification de l’existence d’un audit
