### PR TITLE
perf(app): remove useless highlight.js import

### DIFF
--- a/confiture-web-app/src/components/tiptap/TiptapRenderer.vue
+++ b/confiture-web-app/src/components/tiptap/TiptapRenderer.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
 import { Editor, EditorContent, useEditor } from "@tiptap/vue-3";
-import hljs from "highlight.js";
-import { computed, onMounted, ref, ShallowRef } from "vue";
+import { computed, ref, ShallowRef } from "vue";
 
 import { tiptapRenderedExtensions } from "./tiptap-extensions";
 
@@ -32,12 +31,6 @@ const editor = useEditor({
 }) as ShallowRef<Editor>;
 
 const contentRef = ref<HTMLDivElement>();
-
-onMounted(() => {
-  contentRef.value?.querySelectorAll("pre code").forEach((el) => {
-    hljs.highlightElement(el as HTMLElement);
-  });
-});
 </script>
 
 <template>


### PR DESCRIPTION
`highlight.js` était importé dans le `TiptapRenderer` alors qu’on utilise `lowlight` dans la liste des extensions.

le syntax highligting des bouts de code dans l’éditeur riche fonctionne toujours, et la taille du bundle JS est réduite de 40%

```
# avant
dist/assets/index-M3eamoMm.js                       2,641.35 kB │ gzip: 783.18 kB │ map: 7,417.16 kB

# après
dist/assets/index-DZL5gOWk.js                       1,691.78 kB │ gzip: 479.20 kB │ map: 5,431.18 kB
```