### PR TITLE
Ajoute la variable `FRONT_BASE_URL` à sur les déploiements Scalingo

### DIFF
--- a/confiture-rest-api/src/config-validation-schema.ts
+++ b/confiture-rest-api/src/config-validation-schema.ts
@@ -14,13 +14,7 @@ export const configValidationSchema = Joi.object({
   MAILER_SMTP_SECURE: Joi.boolean().required(),
   FRONT_BASE_URL: Joi.string()
     .uri({ scheme: ["http", "https"] })
-    .default((env) => {
-      return (
-        (env.APP && env.REGION_NAME &&
-          `https://${env.APP}.${env.REGION_NAME}.scalingo.io`)
-        || "http://localhost:3000"
-      );
-    }),
+    .default("http://localhost:3000"),
   GRIST_API_KEY: Joi.string().required(),
   GRIST_DOC_ID: Joi.string().required(),
   GRIST_TABLE_ID: Joi.string().required(),

--- a/scalingo.json
+++ b/scalingo.json
@@ -1,0 +1,7 @@
+{
+  "env": {
+    "FRONT_BASE_URL": {
+      "generator": "url"
+    }
+  }
+}


### PR DESCRIPTION
Erreur lors de l'envoi des mails. J'ai rajouté la variable `FRONT_BASE_URL` qui n'était pas présente mais il semble y avoir un autre problème. J'enquête.

Voir logs : https://dashboard.scalingo.com/apps/osc-secnum-fr1/ara-dev-pr1517/logs

```sh
Failed to send email Error: Invalid login: 535 Incorrect authentication data
2026-05-28 17:03:21.401836748 +0200 CEST[web-1] ::ffff:10.0.0.33 - POST /api/audits HTTP/1.1 201 1007 - 101.598 ms
2026-05-28 17:03:21.483182326 +0200 CEST[web-1] at TLSSocket.emit (node:events:519:28)
2026-05-28 17:03:21.483284160 +0200 CEST[web-1] code: 'EAUTH',
2026-05-28 17:03:21.483169346 +0200 CEST[web-1] at SMTPConnection._formatError (/app/node_modules/nodemailer/lib/smtp-connection/index.js:809:19)
2026-05-28 17:03:21.483183314 +0200 CEST[web-1] at Readable.push (node:internal/streams/readable:392:5) {
2026-05-28 17:03:21.483181949 +0200 CEST[web-1] at SMTPConnection._onSocketData (/app/node_modules/nodemailer/lib/smtp-connection/index.js:195:44)
2026-05-28 17:03:21.483180592 +0200 CEST[web-1] at SMTPConnection.<anonymous> (/app/node_modules/nodemailer/lib/smtp-connection/index.js:556:26)
2026-05-28 17:03:21.483284897 +0200 CEST[web-1] responseCode: 535,
2026-05-28 17:03:21.483285155 +0200 CEST[web-1] command: 'AUTH PLAIN' 
```
