### PR TITLE
Corrige l'affichage des numéro de list des tests de méthodologie sur chrome

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 <h2 class="fr-sr-only" id="2026">2026</h2>
 
+### 04/06/2026
+
+#### <span aria-hidden="true">🐛</span> Corrections
+
+- Corrige l’affichage des listes numérotées des tests de méthodologie sur Chrome ([#1522](https://github.com/DISIC/Ara/pull/1522))
+
 ### 22/05/2026
 
 #### <span aria-hidden="true">🐛</span> Corrections

--- a/confiture-web-app/src/components/audit/CriteriumTestsAccordion.vue
+++ b/confiture-web-app/src/components/audit/CriteriumTestsAccordion.vue
@@ -88,8 +88,7 @@ const methodologiesHtml = Object.values(
 }
 
 /* Fixes ol numbering used by dsfr to only show the test number. */
-.criterium-test-methodology :deep(ol) {
-  counter-reset: none;
-  counter-set: li-counter 0;
+.criterium-test-methodology :deep(ol > li::marker) {
+  content: counter(li-counter) ". ";
 }
 </style>


### PR DESCRIPTION
Testé et fonctionne sur Firefox, Safari et Chrome.

closes #1514 