### PR TITLE
Supprime les attributs `target` et les `span` d'a11é dans les liens du code copié de la déclaration

### DIFF
--- a/confiture-web-app/src/pages/StatementPage.vue
+++ b/confiture-web-app/src/pages/StatementPage.vue
@@ -61,7 +61,11 @@ function getA11yStatementHTML(): string {
     .replaceAll(whitespaceFollowingTags, "</$<tagName>>")
     .replaceAll(oneLineBreakTags, "<$<tagName>>\n")
     .replaceAll(twoLineBreakTags, "</$<tagName>>\n\n")
-    .replaceAll(indentedTags, "  <$<tagName>>");
+    .replaceAll(indentedTags, "  <$<tagName>>")
+
+    // Remove extra <a> attributes
+    .replaceAll(" target=\"_blank\"", "")
+    .replaceAll(" <span>(nouvelle fenêtre)</span>", "");
 }
 
 const statementIsPublished = computed(() => {

--- a/confiture-web-app/src/pages/StatementPage.vue
+++ b/confiture-web-app/src/pages/StatementPage.vue
@@ -292,7 +292,7 @@ const siteUrl = computed(() => {
               </template>
             </p>
             <h5 class="fr-h3">
-              Technologies utilisées pour la réalisation de l’audit
+              Technologies utilisées pour la réalisation du site
             </h5>
             <ul class="fr-mb-2w fr-mb-md-3w">
               <li v-for="tech in report.data.context.technologies" :key="tech">

--- a/confiture-web-app/src/pages/misc/AccessibilityPage.vue
+++ b/confiture-web-app/src/pages/misc/AccessibilityPage.vue
@@ -18,7 +18,7 @@ import TopLink from "../../components/ui/TopLink.vue";
     <p>L’audit de conformité réalisé par <strong>la Brigade d'Intervention du Numérique de la DINUM</strong> révèle que <strong>100&nbsp;%</strong> des critères du RGAA version 4.1.2 sont respectés.</p>
     <h2> Établissement de cette déclaration d’accessibilité </h2>
     <p>Cette déclaration a été établie le <strong>23 avril 2025</strong>. Elle a été mise à jour le <strong>9 octobre 2025</strong>.</p>
-    <h3> Technologies utilisées pour la réalisation de l’audit </h3>
+    <h3>Technologies utilisées pour la réalisation du site</h3>
     <ul>
       <li>HTML</li>
       <li>CSS</li>
@@ -41,7 +41,7 @@ import TopLink from "../../components/ui/TopLink.vue";
       <li>Inspecteur de composants</li>
       <li>Validateur HTML du W3C</li>
     </ul>
-    <h3> Pages du site ayant fait l’objet de la vérification de conformité </h3>
+    <h3>Pages du site ayant fait l’objet de la vérification de conformité</h3>
     <ul>
       <li>Accueil <strong>https://ara.numerique.gouv.fr/</strong></li>
       <li>Contact et contributions <strong>https://ara.numerique.gouv.fr/contact-contributions</strong></li>


### PR DESCRIPTION
closes #1532 