### PR TITLE
Changer la façon d’activer le mode debug

### DIFF
--- a/confiture-rest-api/prisma.config.ts
+++ b/confiture-rest-api/prisma.config.ts
@@ -10,7 +10,7 @@ export default defineConfig({
   migrations: {
     path: "prisma/migrations",
     // Only allow seeding on dev and review environnments
-    seed: process.env.NODE_ENV !== "production" || process.env.IS_REVIEW_APP
+    seed: process.env.NODE_ENV !== "production" || process.env.IS_REVIEW_APP === "true"
       ? "yarn dlx tsx prisma/seed.ts"
       : undefined
   },

--- a/confiture-rest-api/src/debug/debug.controller.ts
+++ b/confiture-rest-api/src/debug/debug.controller.ts
@@ -1,6 +1,6 @@
-import { Body, Controller, Post, UnauthorizedException } from "@nestjs/common";
+import { Body, Controller, Get, Post, UnauthorizedException } from "@nestjs/common";
 import { ConfigService } from "@nestjs/config";
-import { ApiCreatedResponse, ApiTags } from "@nestjs/swagger";
+import { ApiCreatedResponse, ApiOkResponse, ApiTags } from "@nestjs/swagger";
 import { nanoid } from "nanoid";
 import { AuthenticationJwtPayload } from "src/auth/jwt-payloads";
 import { User } from "src/auth/user.decorator";
@@ -21,6 +21,16 @@ export class DebugController {
     private readonly prisma: PrismaService,
     private readonly config: ConfigService
   ) {}
+
+  @Get("is-dev-mode-allowed")
+  @ApiOkResponse({
+    description: "Display dev mode switch or not",
+    type: Boolean
+  })
+  async isDevModeAllowed(): Promise<boolean> {
+    const isProd = this.config.get("NODE_ENV") === "production";
+    return !isProd;
+  }
 
   @Post("create-audit")
   @ApiCreatedResponse({

--- a/confiture-rest-api/src/debug/debug.controller.ts
+++ b/confiture-rest-api/src/debug/debug.controller.ts
@@ -48,7 +48,6 @@ export class DebugController {
     const adminAccounts = this.config.get("ADMIN_ACCOUNTS");
     const adminUsers = adminAccounts ? adminAccounts.split(",") : [];
     const userIsNotAuthorized = this.config.get("NODE_ENV") === "production" && this.config.get("IS_REVIEW_APP") !== "true" && adminUsers && (!user || !adminUsers.includes(user.email));
-
     if (userIsNotAuthorized) {
       throw new UnauthorizedException();
     }

--- a/confiture-rest-api/src/debug/debug.controller.ts
+++ b/confiture-rest-api/src/debug/debug.controller.ts
@@ -28,7 +28,7 @@ export class DebugController {
     type: Boolean
   })
   async isDevModeAllowed(): Promise<boolean> {
-    const isProd = this.config.get("NODE_ENV") === "production";
+    const isProd = this.config.get("NODE_ENV") === "production" && !process.env.IS_REVIEW_APP;
     return !isProd;
   }
 
@@ -47,7 +47,7 @@ export class DebugController {
     // Only allow admins to use route on production
     const adminAccounts = this.config.get("ADMIN_ACCOUNTS");
     const adminUsers = adminAccounts ? adminAccounts.split(",") : [];
-    const userIsNotAuthorized = this.config.get("NODE_ENV") === "production" && adminUsers && (!user || !adminUsers.includes(user.email));
+    const userIsNotAuthorized = this.config.get("NODE_ENV") === "production" && !process.env.IS_REVIEW_APP && adminUsers && (!user || !adminUsers.includes(user.email));
 
     if (userIsNotAuthorized) {
       throw new UnauthorizedException();

--- a/confiture-rest-api/src/debug/debug.controller.ts
+++ b/confiture-rest-api/src/debug/debug.controller.ts
@@ -28,7 +28,7 @@ export class DebugController {
     type: Boolean
   })
   async isDevModeAllowed(): Promise<boolean> {
-    const isProd = this.config.get("NODE_ENV") === "production" && !process.env.IS_REVIEW_APP;
+    const isProd = this.config.get("NODE_ENV") === "production" && this.config.get("IS_REVIEW_APP") !== "true";
     return !isProd;
   }
 
@@ -47,7 +47,7 @@ export class DebugController {
     // Only allow admins to use route on production
     const adminAccounts = this.config.get("ADMIN_ACCOUNTS");
     const adminUsers = adminAccounts ? adminAccounts.split(",") : [];
-    const userIsNotAuthorized = this.config.get("NODE_ENV") === "production" && !process.env.IS_REVIEW_APP && adminUsers && (!user || !adminUsers.includes(user.email));
+    const userIsNotAuthorized = this.config.get("NODE_ENV") === "production" && this.config.get("IS_REVIEW_APP") !== "true" && adminUsers && (!user || !adminUsers.includes(user.email));
 
     if (userIsNotAuthorized) {
       throw new UnauthorizedException();

--- a/confiture-web-app/src/App.vue
+++ b/confiture-web-app/src/App.vue
@@ -6,6 +6,7 @@ import GenericModal from "./components/GenericModal.vue";
 import SiteFooter from "./components/layout/SiteFooter.vue";
 import SiteHeader from "./components/layout/SiteHeader.vue";
 import ToastNotification from "./components/ui/ToastNotification.vue";
+import { useDebugStore } from "./store";
 import { useAccountStore } from "./store/account";
 
 // Default meta tags
@@ -30,6 +31,9 @@ useHead({
     { name: "twitter:card", content: "summary_large_image" }
   ]
 });
+
+const debugStore = useDebugStore();
+debugStore.initDevModeSwitch();
 
 const accountStore = useAccountStore();
 onMounted(() => {

--- a/confiture-web-app/src/App.vue
+++ b/confiture-web-app/src/App.vue
@@ -109,7 +109,7 @@ function closeFeedbackNotice() {
     </div>
   </div>
 
-  <main id="main" role="main" class="fr-container fr-mb-12w fr-pt-5w">
+  <main id="main" role="main" class="fr-container fr-mb-12w fr-pt-5w" tabindex="-1">
     <RouterView />
   </main>
 

--- a/confiture-web-app/src/components/DebugCard.vue
+++ b/confiture-web-app/src/components/DebugCard.vue
@@ -1,7 +1,4 @@
 <script setup lang="ts">
-/**
- * Component is shown under "?dev=1" in every env although debug API routes are disabled in production.
- */
 import { ref } from "vue";
 
 import { useNotifications } from "../composables/useNotifications";

--- a/confiture-web-app/src/components/layout/SiteFooter.vue
+++ b/confiture-web-app/src/components/layout/SiteFooter.vue
@@ -189,8 +189,9 @@ function switchDevMode() {
           </li>
           <li v-if="debugStore.allowDevMode" class="fr-footer__bottom-item">
             <button
+              type="button"
               class="fr-footer__bottom-link fr-icon-computer-line fr-link--icon-left"
-              @click.prevent="switchDevMode"
+              @click="switchDevMode"
             >
               <template v-if="debugStore.devMode">Désactiver le mode développeur</template>
               <template v-else>Activer le mode développeur</template>

--- a/confiture-web-app/src/components/layout/SiteFooter.vue
+++ b/confiture-web-app/src/components/layout/SiteFooter.vue
@@ -1,9 +1,11 @@
 <script setup lang="ts">
 import fiphfpLogo from "../../assets/images/fiphfp.png";
+import { useDebugStore } from "../../store";
 import { useAccountStore } from "../../store/account";
 import ThemeModal from "./ThemeModal.vue";
 
 const accountStore = useAccountStore();
+const debugStore = useDebugStore();
 
 const bottomLinks = [
   {
@@ -27,6 +29,10 @@ const bottomLinks = [
     routeName: "contact"
   }
 ];
+
+function switchDevMode() {
+  debugStore.saveDevMode(!debugStore.devMode);
+}
 </script>
 
 <template>
@@ -179,6 +185,15 @@ const bottomLinks = [
               data-fr-opened="false"
             >
               Paramètres d'affichage
+            </button>
+          </li>
+          <li v-if="debugStore.allowDevMode" class="fr-footer__bottom-item">
+            <button
+              class="fr-footer__bottom-link fr-icon-computer-line fr-link--icon-left"
+              @click.prevent="switchDevMode"
+            >
+              <template v-if="debugStore.devMode">Désactiver le mode développeur</template>
+              <template v-else>Activer le mode développeur</template>
             </button>
           </li>
         </ul>

--- a/confiture-web-app/src/composables/useDevMode.ts
+++ b/confiture-web-app/src/composables/useDevMode.ts
@@ -1,10 +1,16 @@
-import { computed } from "vue";
-import { useRoute } from "vue-router";
+import { ref, watch } from "vue";
+import { useDebugStore } from "../store";
 
 export function useDevMode() {
-  const route = useRoute();
-  const isDevMode = computed(() => {
-    return !!route.query.dev;
-  });
+  const debugStore = useDebugStore();
+  const isDevMode = ref(debugStore.devMode);
+
+  watch(
+    () => debugStore.devMode,
+    () => {
+      isDevMode.value = debugStore.devMode;
+    }
+  );
+
   return isDevMode;
 }

--- a/confiture-web-app/src/router.ts
+++ b/confiture-web-app/src/router.ts
@@ -369,18 +369,6 @@ const router = createRouter({
   }
 });
 
-router.beforeEach((to, from) => {
-  if (from.query.dev && !to.query.dev) {
-    return {
-      ...to,
-      query: {
-        ...to.query,
-        dev: from.query.dev
-      }
-    };
-  }
-});
-
 router.beforeEach((to) => {
   const accountStore = useAccountStore();
   if (to.meta.authRequired && !accountStore.account) {

--- a/confiture-web-app/src/store/debug.ts
+++ b/confiture-web-app/src/store/debug.ts
@@ -2,8 +2,46 @@ import { defineStore } from "pinia";
 import { api } from "../api";
 import { Audit, CreateDebugAuditRequestData } from "../types";
 
+const lsAllowDevModeKey = "ara:allow-dev-mode";
+const lsDevModeKey = "ara:dev-mode";
+
 export const useDebugStore = defineStore("debug", {
+
+  state: () => {
+    return {
+      allowDevMode: false,
+      devMode: false
+    };
+  },
   actions: {
+    async initDevModeSwitch() {
+      const allowDevModeFromLS = localStorage.getItem(lsAllowDevModeKey);
+      let allowDevMode: boolean;
+      if (allowDevModeFromLS === "true" || allowDevModeFromLS === "false") {
+        // check if dev mode is allowed from local storage "ara:allow-dev-mode" key
+        allowDevMode = (allowDevModeFromLS === "true");
+      } else {
+        // check if server allows dev mode
+        allowDevMode = await api.get("/api/debug/is-dev-mode-allowed").json() as boolean;
+      }
+      this.allowDevMode = allowDevMode;
+
+      const devModeFromLS = localStorage.getItem(lsDevModeKey);
+      if (!allowDevMode) {
+        // dev mode deactivated if dev mode is not allowed
+        this.devMode = false;
+      } else if (devModeFromLS === "true" || devModeFromLS === "false") {
+        // set dev mode from local storage "ara:dev-mode" key value
+        this.devMode = (devModeFromLS === "true");
+      } else {
+        // By default, if dev mode is allowed, dev mode is activated
+        this.devMode = true;
+      }
+    },
+    saveDevMode(devMode: boolean) {
+      this.devMode = devMode;
+      localStorage.setItem(lsDevModeKey, devMode ? "true" : "false");
+    },
     async createDebugAudit(data: CreateDebugAuditRequestData) {
       const response = (await api
         .post("/api/debug/create-audit", {

--- a/confiture-web-app/src/store/debug.ts
+++ b/confiture-web-app/src/store/debug.ts
@@ -17,7 +17,7 @@ export const useDebugStore = defineStore("debug", {
     async initDevModeSwitch() {
       const allowDevModeFromLS = localStorage.getItem(lsAllowDevModeKey);
       let allowDevMode: boolean;
-      if (allowDevModeFromLS === "true" || allowDevModeFromLS === "false") {
+      if (allowDevModeFromLS) {
         // check if dev mode is allowed from local storage "ara:allow-dev-mode" key
         allowDevMode = (allowDevModeFromLS === "true");
       } else {
@@ -40,7 +40,7 @@ export const useDebugStore = defineStore("debug", {
     },
     saveDevMode(devMode: boolean) {
       this.devMode = devMode;
-      localStorage.setItem(lsDevModeKey, devMode ? "true" : "false");
+      localStorage.setItem(lsDevModeKey, devMode.toString());
     },
     async createDebugAudit(data: CreateDebugAuditRequestData) {
       const response = (await api


### PR DESCRIPTION
Plutôt qu’utiliser un chaîne de requête dans l’URL (`?dev=1`), le mode debug est désormais activable via un bouton dans le pied de page.

Ce bouton est visible et activé par défaut sur tous les environnements sauf sur l’environnement de production.
Il est possible de forcer l’affichage de ce bouton en ajoutant/modifiant la clé suivante dans le _local storage_ :
`ara:allow-dev-mode`: `true` | `false`

closes #1524 

Avant de merger la pull request, s’assurer que :

- Les checks GitHub passent (lint...).
- Les tests Cypress ont été lancés en local (dans le cas d’une correction de bug ou d’une nouvelle fonctionnalité).
